### PR TITLE
Add support for context cancellation, pluggable logger

### DIFF
--- a/ksql/client.go
+++ b/ksql/client.go
@@ -3,6 +3,7 @@ package ksql
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,18 +14,40 @@ import (
 	"strings"
 )
 
+// Logger provides a pluggable interface for caller-provided loggers
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
 // Client provides a client to interact with the KSQL REST API
 type Client struct {
+	context.Context
 	client *http.Client
 	host   string
+	Logger
 }
 
 // NewClient returns a new client
 func NewClient(host string) *Client {
+	return NewClientContext(context.Background(), host)
+}
+
+// NewClientContext returns a new client which supports cancelation
+// via the context
+func NewClientContext(ctx context.Context, host string) *Client {
 	return &Client{
-		host:   host,
-		client: &http.Client{},
+		Context: ctx,
+		host:    host,
+		client:  &http.Client{},
+		Logger:  stdLogger{},
 	}
+}
+
+type stdLogger struct{}
+
+// Printf implements the Logger interface
+func (stdLogger) Printf(fmt string, args ...interface{}) {
+	log.Printf(fmt, args...)
 }
 
 // ListStreams returns a slice of available streams
@@ -90,6 +113,7 @@ func (c *Client) Status(commandID string) (*StatusResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(c)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -122,12 +146,16 @@ func (c *Client) Query(r Request, ch chan *QueryResponse) error {
 			break
 		}
 		if err != nil {
-			log.Println(err)
+			c.Logger.Printf("error reading results from ksql query %#v: %s", r.KSQL, err)
 		}
 		if q == nil {
 			continue
 		}
-		ch <- q
+		select {
+		case ch <- q:
+		case <-c.Done():
+			return nil
+		}
 	}
 	return err
 }
@@ -169,6 +197,7 @@ func (c *Client) doQuery(r Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(c)
 
 	req.Header.Set("Content-Type", "application/json")
 	return c.client.Do(req)
@@ -197,6 +226,7 @@ func (c *Client) ksqlRequest(r Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(c)
 
 	req.Header.Set("Content-Type", "application/json")
 	return c.client.Do(req)


### PR DESCRIPTION
Currently clients would only be stopped by query
back-pressure, but if the query does not match many results
this could take a long time.  Add a new constructor that
takes a stdlib context, and pass it through to the HTTP
Client Request.

Also a little change in there to allow the caller to provide
their own logger.