### PR TITLE
Don't loop forever on permanent errors

### DIFF
--- a/ksql/client.go
+++ b/ksql/client.go
@@ -147,7 +147,7 @@ func (c *Client) QueryContext(ctx context.Context, r Request, ch chan *QueryResp
 	reader := bufio.NewReader(resp.Body)
 	for {
 		q, err := readQR(reader)
-		if err == io.EOF {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			break
 		}
 		if err != nil {

--- a/ksql/client.go
+++ b/ksql/client.go
@@ -152,6 +152,9 @@ func (c *Client) QueryContext(ctx context.Context, r Request, ch chan *QueryResp
 		}
 		if err != nil {
 			c.Logger.Printf("error reading results from ksql query %#v: %s", r.KSQL, err)
+			if err, ok := err.(net.Error); ok && !err.Temporary() {
+				return err
+			}
 		}
 		if q == nil {
 			continue


### PR DESCRIPTION
Once the connection is closed, any read will return a permanent
~~net.Error~~ io.ErrUnexpectedEOF; detect this and break out.