### PR TITLE
Update structs for newer KSQL

### DIFF
--- a/ksql/client.go
+++ b/ksql/client.go
@@ -62,7 +62,7 @@ func (c *Client) ListStreams() ([]Stream, error) {
 	if len(resp) < 1 {
 		return nil, errors.New("Didn't get enough responses")
 	}
-	return resp[0].Streams.Streams, nil
+	return resp[0].Streams, nil
 }
 
 // ListTables returns a slice of available tables
@@ -77,7 +77,7 @@ func (c *Client) ListTables() ([]Table, error) {
 	if len(resp) < 1 {
 		return nil, errors.New("Didn't get enough responses")
 	}
-	return resp[0].Tables.Tables, nil
+	return resp[0].Tables, nil
 }
 
 // Do provides a way for running queries against the `/ksql` endpoint
@@ -101,8 +101,8 @@ func (c *Client) Do(r Request) (Response, error) {
 		return nil, err
 	}
 
-	if resp[0].Error != nil {
-		return nil, errors.New(resp[0].Error.ErrorMessage.Message + "\n" + strings.Join(resp[0].Error.ErrorMessage.StackTrace, "\n"))
+	if resp[0].ErrorCode != 0 {
+		return nil, errors.New(resp[0].Message + "\n" + strings.Join(resp[0].StackTrace, "\n"))
 	}
 	return resp, nil
 }

--- a/ksql/structs.go
+++ b/ksql/structs.go
@@ -10,6 +10,7 @@ type QueryResponse struct {
 		Columns []interface{} `json:"columns"`
 	} `json:"row"`
 	ErrorMessage ErrorMessage `json:"errorMessage"`
+	FinalMessage ErrorMessage `json:"finalMessage"`
 }
 
 type Request struct {
@@ -19,26 +20,26 @@ type Request struct {
 }
 
 type Response []struct {
-	Error *struct {
-		StatementText string       `json:"statementText"`
-		ErrorMessage  ErrorMessage `json:"errorMessage"`
-	} `json:"error,omitempty"`
-	Streams *struct {
-		StatementText string   `json:"statementText"`
-		Streams       []Stream `json:"streams"`
-	} `json:"streams"`
-	Tables *struct {
-		StatementText string  `json:"statementText"`
-		Tables        []Table `json:"tables"`
-	} `json:"tables"`
-	Status *struct {
-		StatementText string `json:"statementText"`
-		CommandID     string `json:"commandId"`
-		CommandStatus *struct {
-			Message string `json:"message"`
-			Status  string `json:"status"`
-		} `json:"commandStatus"`
-	} `json:"currentStatus"`
+	Type          string `json:"@type"`
+	StatementText string `json:"statementText"`
+
+	// error responses
+	StackTrace []string `json:"stackTrace"`
+	ErrorCode  int      `json:"error_code"`
+	Message    string   `json:"message"`
+	// plus entities... list of something
+
+	// response to various queries
+	Streams   []Stream   `json:"streams"`
+	Tables    []Table    `json:"tables"`
+	Queries   []Query    `json:"queries"`
+	Topics    []Topic    `json:"topics"`
+	Functions []Function `json:"functions"`
+
+	// responses to 'show properties'
+	Properties            map[string]string `json:"properties"`
+	OverwrittenProperties []string          `json:"overwrittenProperties"`
+	DefaultProperties     []string          `json:"defaultProperties"`
 }
 
 type StatusResponse struct {
@@ -52,7 +53,30 @@ type Stream struct {
 	Format string `json:"format"`
 }
 type Table struct {
-	Name   string `json:"name"`
-	Topic  string `json:"topic"`
-	Format string `json:"format"`
+	Name     string `json:"name"`
+	Topic    string `json:"topic"`
+	Format   string `json:"format"`
+	Windowed bool   `json:"isWindowed"`
+}
+
+// Query is an item in a 'SHOW QUERIES' response
+type Query struct {
+	ID    string   `json:"id"`
+	Sinks []string `json:"sinks"` // streams/tables, presumably
+	KSQL  string   `json:"queryString"`
+}
+
+// Topic is an item in a 'SHOW TOPICS' response
+type Topic struct {
+	Name           string `json:"name"`
+	Registered     bool   `json:"registered"`
+	ReplicaInfo    []int  `json:"replicaInfo"`
+	Consumers      int    `json:"consumerCount"`
+	GroupConsumers int    `json:"consumerGroupCount"`
+}
+
+// Function is an item in a 'SHOW FUNCTIONS' response
+type Function struct {
+	Name string `json:"name"`
+	Type string `json:"type"` // 'scalar' or 'aggregate'
 }


### PR DESCRIPTION
Looks like current KSQL versions have a different structure for their
responses.  Update to the newer format without preserving backwards
compatibility - it's possible that the older structure was for very
early developer preview versions.

@Mongey - for your consideration.  Not sure how valuable backwards compatibility is, or in which version the format changed.  KSQL has changed a lot since the original structs were written.  This works on v5.2.1.